### PR TITLE
Fix where of old models in version 2.0.0

### DIFF
--- a/src/io/conekta/Order.java
+++ b/src/io/conekta/Order.java
@@ -118,7 +118,7 @@ public class Order extends Resource {
 
     public static ConektaList where(JSONObject params) throws Error, JSONException, ErrorList {
         String className = Order.class.getSimpleName();
-        return (ConektaList) scpWhereList(className, params);
+        return (ConektaList) scpWhere(className, params);
     }
 
     public DiscountLine createDiscountLine(JSONObject params) throws JSONException, Error, ErrorList, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {

--- a/src/io/conekta/Resource.java
+++ b/src/io/conekta/Resource.java
@@ -77,18 +77,19 @@ public class Resource extends ConektaObject {
     protected static ConektaObject scpWhere(String className, JSONObject params) throws Error, ErrorList {
         Requestor requestor = new Requestor();
         String url = Resource.classUrl(className);
-        JSONArray jsonArray = (JSONArray) requestor.request("GET", url, params);
-        ConektaObject resource = new ConektaObject();
-        resource.loadFromArray(jsonArray);
-        return resource;
-    }
-    
-    protected static ConektaList scpWhereList(String className, JSONObject params) throws Error, JSONException, ErrorList {
-        Requestor requestor = new Requestor();
-        String url = Resource.classUrl(className);
-        JSONObject jsonObject = (JSONObject) requestor.request("GET", url, params);
-        ConektaList resource = new ConektaList(className);
-        resource.loadFrom(jsonObject);
+        ConektaObject resource = null;
+        if(Conekta.apiVersion.equals("2.0.0")) {
+            JSONObject jsonObject = (JSONObject) requestor.request("GET", url, params);
+            ConektaList conektaListResource = (ConektaList) new ConektaList(className);
+            conektaListResource.loadFrom(jsonObject);
+            
+            resource = (ConektaObject) conektaListResource;
+        } else {
+            JSONArray jsonArray = (JSONArray) requestor.request("GET", url, params);
+            resource = new ConektaObject();
+            resource.loadFromArray(jsonArray);
+        }
+        
         return resource;
     }
     

--- a/test/io/conekta/ChargeTest.java
+++ b/test/io/conekta/ChargeTest.java
@@ -99,6 +99,15 @@ public class ChargeTest extends ConektaBase {
         assertTrue(charges instanceof ConektaObject);
         assertTrue(charges.get(0) instanceof ConektaObject);
     }
+    
+    //@Test
+    public void testSuccesfulWhereV2() throws Exception {
+        setApiVersion("2.0.0");
+        JSONObject where_params = new JSONObject("{'description':'Stogies'}");
+        ConektaObject charges = Charge.where(where_params);
+        assertTrue(charges instanceof ConektaObject);
+        assertTrue(charges.get(0) instanceof ConektaObject);
+    }
 
     //@Test
     public void testSuccesfulBankPMCreate() throws Exception {
@@ -123,6 +132,7 @@ public class ChargeTest extends ConektaBase {
 
     //@Test
     public void testSuccesfulOxxoPMCreate() throws Exception {
+        setApiVersion("1.0.0");
         JSONObject oxxo = new JSONObject("{'cash':{'type':'oxxo'}}");
         JSONObject params = valid_payment_method.put("cash", oxxo.get("cash"));
         Charge charge = Charge.create(params);
@@ -132,6 +142,7 @@ public class ChargeTest extends ConektaBase {
 
     //@Test
     public void testUnsuccesfulPMCreate() throws Exception {
+        setApiVersion("1.0.0");
         JSONObject params = invalid_payment_method.put("card", valid_visa_card.get("card"));
         try {
             Charge.create(params);


### PR DESCRIPTION
The where action of old models like charge, customer etc...
was broken when the plugin uses the 2.0.0 API version.