### PR TITLE
Adding expires_at field

### DIFF
--- a/src/io/conekta/Charge.java
+++ b/src/io/conekta/Charge.java
@@ -10,7 +10,6 @@ public class Charge extends Resource {
 
     public Boolean livemode;
     public Integer created_at;
-    public Integer expires_at;
     public String status;
     public String currency;
     public String description;

--- a/src/io/conekta/Charge.java
+++ b/src/io/conekta/Charge.java
@@ -10,6 +10,7 @@ public class Charge extends Resource {
 
     public Boolean livemode;
     public Integer created_at;
+    public Integer expires_at;
     public String status;
     public String currency;
     public String description;

--- a/src/io/conekta/PaymentMethod.java
+++ b/src/io/conekta/PaymentMethod.java
@@ -5,5 +5,6 @@ package io.conekta;
  * @author mauricio
  */
 public abstract class PaymentMethod extends ConektaObject {
+    public Integer expires_at;
     public String type;
 }

--- a/test/io/conekta/OrderTest.java
+++ b/test/io/conekta/OrderTest.java
@@ -259,20 +259,25 @@ public class OrderTest extends ConektaBase{
 
     //@Test
     public void testSuccesfulSPEIPMCreate() throws Exception {
+        long assertTime;
+        assertTime= tomorrow();
+
         JSONObject chargeParams = new JSONObject("{"
                 + "'payment_method': {"
                 + "    'type': 'spei',"
-                + "    'expires_at': " + tomorrow()
+                + "    'expires_at': " + assertTime
                 + "}, "
                 + "'amount': 35000"
                 + "}");
 
         Order order = Order.create(validOrder.put("customer_info", customerInfo));
 
-        Charge charge = order.createCharge(chargeParams);
+        Charge speiPayment = order.createCharge(chargeParams);
 
+
+        assertTrue(speiPayment.payment_method.expires_at == assertTime);
         assertTrue(order.charges instanceof ConektaList);
-        assertTrue(charge instanceof Charge);
+        assertTrue(speiPayment instanceof Charge);
     }
 
     //@Test
@@ -429,7 +434,8 @@ public class OrderTest extends ConektaBase{
         Charge charge = order.createCharge(chargeParams);
         
         OxxoPayment oxxoPayment = (OxxoPayment) charge.payment_method;
-        
+
+
         assertTrue(order.charges instanceof ConektaList);
         assertTrue(!oxxoPayment.reference.isEmpty());
         assertTrue(oxxoPayment.service_name.equals("OxxoPay"));


### PR DESCRIPTION
feature: Add access to expiry date in order
Return a non accesible attribute in payment method model

When clients usually  request a call to an order object, the order object response does not
comes with all the parameters as mentioned in the issue.The reason for that is because the class that contains the model
does not have declared that variable so the iterator does not match the argument from the json
to any var to fill the value:

Field field = this.getClass().getField(key);
// payment_method/expiry_date
this returns a not found error internally in that way the field required is not present in the response
issue: https://github.com/conekta/issues/issues/1816
