### PR TITLE
Fix/typo in params parameter at error class

### DIFF
--- a/src/io/conekta/Error.java
+++ b/src/io/conekta/Error.java
@@ -66,7 +66,7 @@ public class Error extends Exception {
         
         this.type = type;
         this.code = code;
-        this.params = params;
+        this.params = param;
     }
 
     @Override


### PR DESCRIPTION
**Why is this change neccesary?**
This change let users debug better their wrong sended params

**How does it address the issue?**
fix a typo and let access to params parameter


issues
https://github.com/conekta/conekta-java/issues/66
https://github.com/conekta/issues/issues/2225