### PR TITLE
Add payment source with card relationship and move properties from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ nbdist/
 .DS_Store
 target/
 conf/settings.xml
+.idea
+conekta-java.iml

--- a/src/io/conekta/Card.java
+++ b/src/io/conekta/Card.java
@@ -9,13 +9,16 @@ import org.json.JSONObject;
  *
  * @author mauricio
  */
-public class Card extends Resource {
-    public Customer customer;
+public class Card extends PaymentSource {
     public String name;
     public String last4;
+    public String type;
+    public String bin;
+    public String brand;
+    public String cvc;
+    public Address address;
     public String exp_month;
     public String exp_year;
-    public Boolean deleted;
 
     @Override
     public String instanceUrl() throws Error {
@@ -26,7 +29,11 @@ public class Card extends Resource {
                     Lang.translate("error.resource.id_purchaser", parameters, Conekta.locale), null, null, null);
         }
         String base = this.customer.instanceUrl();
-        return base + "/cards/" + id;
+
+        if(Conekta.apiVersion.equals("1.0.0")){
+            return base + "/cards/" + id;
+        }
+        return base + "/payment_sources/" + id;
     }
 
     @Override
@@ -34,7 +41,9 @@ public class Card extends Resource {
         super.update(params);
     }
 
-    public void delete() throws Error, ErrorList {
-        this.delete("customer", "cards");
+    // this method delete a card in the cards array from customer.
+    @Override
+    public Card delete() throws Error, ErrorList {
+        return (Card) this.delete("customer", "cards");
     }
 }

--- a/src/io/conekta/ConektaList.java
+++ b/src/io/conekta/ConektaList.java
@@ -85,6 +85,4 @@ public class ConektaList extends ConektaObject{
 		builder.append("}");
 		return builder.toString();
 	}
- 
-    
 }

--- a/src/io/conekta/ConektaObject.java
+++ b/src/io/conekta/ConektaObject.java
@@ -60,6 +60,10 @@ public class ConektaObject extends ArrayList {
         try {
             if (className != null) {
                 key = className;
+            }
+            else if (jsonArray.getJSONObject(i).has("type") &&
+                    jsonArray.getJSONObject(i).getString("type").equals("card")) {
+                key = "card";
             } else {
                 key = jsonArray.getJSONObject(i).getString("object");
             }

--- a/src/io/conekta/Customer.java
+++ b/src/io/conekta/Customer.java
@@ -69,7 +69,7 @@ public class Customer extends Resource {
 
                     if(list.elements_type.equals("payment_sources")){
                         for (Object item : list){
-                            PaymentSource source = (PaymentSource) item;
+                            PaymentSource source = (Card) item;
                             source.customer = this;
                         }
                     }
@@ -115,6 +115,10 @@ public class Customer extends Resource {
     }
 
     public Card createCard(JSONObject params) throws Error, ErrorList, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+        if(Conekta.apiVersion.equals("2.0.0")) {
+            return (Card) this.createMemberWithRelation("payment_sources", params, this);
+        }
+
         return (Card) this.createMemberWithRelation("cards", params, this);
     }
 

--- a/src/io/conekta/PaymentSource.java
+++ b/src/io/conekta/PaymentSource.java
@@ -10,15 +10,6 @@ import org.json.JSONObject;
  */
 public class PaymentSource extends Resource{
     public Customer customer;
-    public String type;
-    public String name;
-    public String last4;
-    public String bin;
-    public String brand;
-    public String exp_month;
-    public String exp_year;
-    public String cvc;
-    public Address address;
     public Boolean deleted;
     public Integer expires_at;
     
@@ -31,6 +22,7 @@ public class PaymentSource extends Resource{
                     Lang.translate("error.resource.id_purchaser", parameters, Conekta.locale), null, null, null);
         }
         String base = this.customer.instanceUrl();
+
         return base + "/payment_sources/" + id;
     }
     

--- a/src/io/conekta/Resource.java
+++ b/src/io/conekta/Resource.java
@@ -149,12 +149,22 @@ public class Resource extends ConektaObject {
                 objects.add(conektaObject);
                 field.set(this, objects);
             } else if(field.get(this).getClass().getSimpleName().equals("ConektaList")){
-                className = Utils.getInstance().classes.get(member).toString();
-                conektaObject = (ConektaObject) Class.forName(className).newInstance();
-                conektaObject.loadFromObject(jsonObject);
-                ConektaList list = (ConektaList) field.get(this);
-                
-                list.addElement(conektaObject);
+                if(jsonObject.has("type") && jsonObject.get("type").equals("card")) {
+                    Card card = new Card();
+                    card.loadFromObject(jsonObject);
+                    ConektaList list = (ConektaList) field.get(this);
+
+                    list.addElement(card);
+
+                    conektaObject = card;
+                } else {
+                    className = Utils.getInstance().classes.get(member).toString();
+                    conektaObject = (ConektaObject) Class.forName(className).newInstance();
+                    conektaObject.loadFromObject(jsonObject);
+                    ConektaList list = (ConektaList) field.get(this);
+
+                    list.addElement(conektaObject);
+                }
             } else {
                 className = "io.conekta." + member.substring(0, 1).toUpperCase() + member.substring(1);
                 conektaObject = (ConektaObject) Class.forName(className).newInstance();
@@ -171,7 +181,7 @@ public class Resource extends ConektaObject {
 
         return conektaObject;
     }
-    
+
     protected ConektaObject createMemberWithRelation(String member, JSONObject params, ConektaObject parent) throws NoSuchFieldException, Error, ErrorList, IllegalArgumentException, IllegalAccessException{
         String parentClass = parent.getClass().getSimpleName().toLowerCase();
         

--- a/test/io/conekta/CustomerTest.java
+++ b/test/io/conekta/CustomerTest.java
@@ -12,7 +12,7 @@ public class CustomerTest extends ConektaBase {
     JSONObject valid_payment_method;
     JSONObject invalid_payment_method;
     JSONObject valid_visa_card;
-    JSONObject valid_visa_cardv2;
+    JSONObject validCustomerAndCardInfov2;
     JSONObject travelCustomerInfo;
 
     public CustomerTest() throws JSONException {
@@ -23,19 +23,19 @@ public class CustomerTest extends ConektaBase {
                 + "'cards':['tok_test_visa_4242']"
                 + "}");
         
-        valid_visa_cardv2 = new JSONObject("{"
+        validCustomerAndCardInfov2 = new JSONObject("{"
                 + "'name': 'test name',"
                 + "'email': 'test@test.com',"
                 + "'payment_sources':[{"
                 + "    'token_id': 'tok_test_visa_4242',"
                 + "    'type': 'card' }]"
                 + "}");
-        
+
         travelCustomerInfo = new JSONObject("{" +
-        "  'account_created_at': 1484040996," +
-        "  'first_paid_at': 1485151007," +
-        "  'requires_receipt': true" +    
-        "}");
+                "  'account_created_at': 1484040996," +
+                "  'first_paid_at': 1485151007," +
+                "  'requires_receipt': true" +
+                "}");
     }
 
     //@Test
@@ -109,6 +109,25 @@ public class CustomerTest extends ConektaBase {
     }
 
     //@Test
+    public void testAddCardPaymentSourceToCustomerV2() throws Exception {
+        setApiVersion("2.0.0");
+        Customer customer = Customer.create(validCustomerAndCardInfov2);
+        JSONObject params = new JSONObject("{'type': 'card','token_id':'tok_test_visa_1881'}");
+        customer.createCard(params);
+        assertTrue(((Card) customer.payment_sources.get(0)).last4.equals("4242"));
+        assertTrue(((Card) customer.payment_sources.get(1)).last4.equals("1881"));
+        assertTrue(((Card) customer.payment_sources.get(1)).customer == customer);
+    }
+
+    //@Test
+    public void testDeletePaymentSourceCardV2() throws Exception {
+        setApiVersion("2.0.0");
+        Customer cus = Customer.create(validCustomerAndCardInfov2);
+        ((Card) cus.payment_sources.get(0)).delete();
+        assertTrue(((Card) cus.payment_sources.get(0)).deleted);
+    }
+
+    //@Test
     public Customer testSuccesfulSubscriptionCreateV2() throws Exception {
         Customer customer = Customer.create(valid_visa_card);
         JSONObject params = new JSONObject("{'plan':'gold-plan'}");
@@ -147,7 +166,7 @@ public class CustomerTest extends ConektaBase {
         assertTrue(customer.subscription.plan_id.equals(plan.id));
     }
    
-        //@Test
+    //@Test
     public void testSuccesfulSubscriptionUpdateV2() throws Exception {
         Customer customer = testSuccesfulSubscriptionCreateV2();
         Plan plan = null;
@@ -163,6 +182,7 @@ public class CustomerTest extends ConektaBase {
 
     //@Test
     public void testUnSuccesfulSubscriptionCreate() throws Exception {
+        setApiVersion("1.0.0");
         Customer customer = Customer.create(valid_visa_card);
         JSONObject params = new JSONObject("{'plan':'unexistent-plan'}");
         try {
@@ -243,8 +263,8 @@ public class CustomerTest extends ConektaBase {
     //@Test
     public void testSuccesfulCustomerCreateTravel() throws Exception {
         setApiVersion("2.0.0");
-        valid_visa_cardv2.put("antifraud_info", travelCustomerInfo);
-        Customer customer = Customer.create(valid_visa_cardv2);
+        validCustomerAndCardInfov2.put("antifraud_info", travelCustomerInfo);
+        Customer customer = Customer.create(validCustomerAndCardInfov2);
         assertTrue(customer instanceof Customer);
         assertTrue(customer.antifraud_info.get("account_created_at").equals(1484040996));
         assertTrue(customer.antifraud_info.get("first_paid_at").equals(1485151007));

--- a/test/io/conekta/DiscountLineTest.java
+++ b/test/io/conekta/DiscountLineTest.java
@@ -13,6 +13,7 @@ public class DiscountLineTest extends ConektaBase {
 
     public DiscountLineTest() throws JSONException {
         super();
+        setApiVersion("2.0.0");
         validOrder = new JSONObject(
             "{ 'currency': 'mxn'," +
             "  'metadata': {" +

--- a/test/io/conekta/ErrorListTest.java
+++ b/test/io/conekta/ErrorListTest.java
@@ -12,13 +12,14 @@ public class ErrorListTest extends ConektaBase {
     JSONObject invalidOrder;
 
     public ErrorListTest() throws JSONException {
+        setApiVersion("2.0.0");
         invalidOrder = new JSONObject("{}");
     }
 
     // @Test
     public void testNoIdError() throws Error{
         try {
-                Order.find("0");
+            Order.find("0");
         } catch(ErrorList e) {
             assertTrue(e.details.get(0).message.equals("El recurso no ha sido encontrado."));
         }

--- a/test/io/conekta/LogTest.java
+++ b/test/io/conekta/LogTest.java
@@ -15,12 +15,12 @@ public class LogTest extends ConektaBase {
     }
 
     public void testSuccesfulFind() throws Exception {
-        Log log = Log.find("59ad9325b795b02ebdfef2be");
+        Log log = Log.find("5aa6bb38edbb6e3d63c7156d");
         assertTrue(log instanceof ConektaObject);
     }
 
     public void testSuccesfulWhereWithParams() throws Exception {
-        JSONObject params = new JSONObject("{'id':'59ad9325b795b02ebdfef2be'}");
+        JSONObject params = new JSONObject("{'id':'5aa6bb38edbb6e3d63c7156d'}");
         ConektaObject log = Log.where(params);
         assertTrue(log instanceof ConektaObject);
     }

--- a/test/io/conekta/PaymentSourceTest.java
+++ b/test/io/conekta/PaymentSourceTest.java
@@ -9,16 +9,24 @@ import org.json.JSONObject;
  */
 public class PaymentSourceTest  extends ConektaBase {
     JSONObject validCustomer;
+    JSONObject validOxxoRecurrentCustomer;
 
     public PaymentSourceTest() throws JSONException{
         validCustomer  = new JSONObject("{" +
-        "  'email': 'hola@hola.com'," +
-        "  'name': 'John Constantine'," +
-        "  'payment_sources': [{" +
-        "    'token_id': 'tok_test_visa_4242'," +
-        "    'type': 'card'" +
-        "  }]" +
-        "}");
+                "  'email': 'hola@hola.com'," +
+                "  'name': 'John Constantine'," +
+                "  'payment_sources': [{" +
+                "    'token_id': 'tok_test_visa_4242'," +
+                "    'type': 'card'" +
+                "  }]" +
+                "}");
+    }
+
+    public void testSuccesfulCardPaymentSource() throws Error, ErrorList{
+        Customer customer = Customer.create(validCustomer);
+        Card card = (Card) customer.payment_sources.get(0);
+        assertTrue(card instanceof Card);
+        assertTrue(card.last4.equals("4242"));
     }
 
     // @Test
@@ -40,6 +48,8 @@ public class PaymentSourceTest  extends ConektaBase {
 
         source.update(new JSONObject("{'exp_month': '11'}"));
 
-        assertTrue(source.exp_month.equals("11"));
+        Card card = (Card) source;
+
+        assertTrue(card.exp_month.equals("11"));
     }
 }


### PR DESCRIPTION
payment source to card.

Why is this change neccesary?

In order to have an unique payment source array that contains
OfflineRecurrentReference and Card objets we need to move card
propierties from payment source to Card and make a relationship between
them.

How does it address the issue?

Add PaymentSource as parent class of Card and move card propierties from
payment source to card class.

What side effects does this change have?

Well customer.cards is no longer working and instead the merchant
developer must use customer.payment_sources. This could break the
merchant integration. We need a deploy plan.